### PR TITLE
Linking to Rhtslib when system version also installed

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rhtslib
 Type: Package
 Title: HTSlib high-throughput sequencing library as an R package
-Version: 1.17.0
+Version: 1.17.1
 Authors@R:
     c(person("Nathaniel", "Hayden", email="nhayden@fredhutch.org",
         role=c("led", "aut")),

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -23,7 +23,7 @@ pkgconfig <- function(opt=c("PKG_LIBS", "PKG_CPPFLAGS"))
                 ## htslib-1.7/Makefile.Rhtslib and make sure
                 ## to use the same value here.
                 htslib_default_libs <- "-lz -lm -lbz2 -llzma"
-                config <- sprintf('-L%s -Wl,-rpath,%s -lhts %s -lpthread',
+                config <- sprintf('-L%s -Wl,--disable-new-dtags -Wl,-rpath,%s -lhts %s -lpthread',
                                   usrlib_dir, usrlib_dir, htslib_default_libs)
             }
         }

--- a/src/Makevars
+++ b/src/Makevars
@@ -24,7 +24,7 @@ htslib_default_libs=-lz -lm -lbz2 -llzma
 
 ## Linker options. Make sure to keep Rhtslib::pkgconfig() function (defined
 ## in R/zzz.R) in sync with this.
-PKG_LIBS=-L"${USRLIB_DIR}" -Wl,-rpath,"${USRLIB_DIR}" -lhts ${htslib_default_libs} -lpthread
+PKG_LIBS=-L"${USRLIB_DIR}" -Wl,--disable-new-dtags -Wl,-rpath,"${USRLIB_DIR}" -lhts ${htslib_default_libs} -lpthread
 
 populate-usrlib-dir: htslib mk-usrlib-dir
 	cd "${HTSLIB_SOURCE_DIR}" && cp libhts.so libhts.a "${USRLIB_DIR}"


### PR DESCRIPTION
Describing what I think's happening in https://support.bioconductor.org/p/120529  Hopefully this is helpful going forward.

---

I could reproduce the errors the other users are seeing after installing a system level version of **htslib** via `apt-get install libhts-dev`.  It also only manifests if I compile with **gcc**, my version of R compiled with **clang** is fine regardless.

I think the problem is that `-Wl,-rpath,/Rhtslib/dir` is not working quite as expected with some combo of gcc/Ubuntu/...

If I check the header of the current version of `Rsamtools.so` for the `RPATH` I see this:

```
readelf -d Rsamtools/src/Rsamtools.so | head -n 11

Dynamic section at offset 0x53c80 contains 31 entries:
  Tag        Type                         Name/Value
 0x0000000000000001 (NEEDED)             Shared library: [libhts.so.2]
 0x0000000000000001 (NEEDED)             Shared library: [libz.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libpthread.so.0]
 0x0000000000000001 (NEEDED)             Shared library: [libR.so]
 0x0000000000000001 (NEEDED)             Shared library: [libstdc++.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]
 0x000000000000000f (RUNPATH)            Library rpath: [/home/mike/R/x86_64-pc-linux-gnu-library/3.6/Rhtslib/usrlib]
```

Note, that it's `RUNPATH` rather than `RPATH`.  There's quite a few discussion about the difference between RPATH and RUNPATH ([this](https://gitlab.kitware.com/cmake/community/wikis/doc/cmake/RPATH-handling) write up works for me) but I think the pertinent info is:

- RPATH - a list of directories which is linked into the executable, supported on most UNIX systems. It is ignored if RUNPATH is present. 
- LD_LIBRARY_PATH - an environment variable which holds a list of directories
- RUNPATH - same as RPATH, but searched after LD_LIBRARY_PATH, supported only on most recent UNIX systems, e.g. on most current Linux systems

If we check the `LD_LIBRARY_PATH` within R I get:
```
> Sys.getenv("LD_LIBRARY_PATH")
[1] "/usr/lib/R/lib:/usr/lib/x86_64-linux-gnu:/usr/lib/jvm/default-java/lib/server"
```
and for me I have a `libhts.so` in `/usr/lib/x86_64-linux-gnu` which is presumably taking precedence but was not the version linked against during installation.

One way to restore the behaviour or really setting the `RPATH` is to use the `-Wl,--disable-new-dtags` which is what this pull request does.  Presumably there's a reason this behaviour was changed, so maybe it would be preferable to link statically?  