### PR TITLE
Prevent overwriting of CFLAGS and LDFLAGS

### DIFF
--- a/src/htslib-1.7/Makefile.Rhtslib
+++ b/src/htslib-1.7/Makefile.Rhtslib
@@ -37,15 +37,15 @@
 # Default libraries to link if configure is not used
 htslib_default_libs = -lz -lm -lbz2 -llzma
 
-CPPFLAGS =
+# CPPFLAGS =
 # TODO: probably update cram code to make it compile cleanly with -Wc++-compat
 # For testing strict C99 support add -std=c99 -D_XOPEN_SOURCE=600
 #CFLAGS   = -g -Wall -O2 -pedantic -std=c99 -D_XOPEN_SOURCE=600 -D__FUNCTION__=__func__
 #CFLAGS   = -g -Wall -O2
-CFLAGS   = -g -Wall -O2 -fpic
+CFLAGS   += -g -Wall -O2 -fpic
 #EXTRA_CFLAGS_PIC = -fpic
 EXTRA_CFLAGS_PIC =
-LDFLAGS  =
+#LDFLAGS  =
 LIBS     = $(htslib_default_libs)
 
 prefix      = /usr/local

--- a/src/htslib-1.7/Makefile.Rhtslib.win
+++ b/src/htslib-1.7/Makefile.Rhtslib.win
@@ -37,13 +37,13 @@
 # Default libraries to link if configure is not used
 htslib_default_libs = -lz -lm -lws2_32
 
-CPPFLAGS =
+#CPPFLAGS =
 # TODO: probably update cram code to make it compile cleanly with -Wc++-compat
 # For testing strict C99 support add -std=c99 -D_XOPEN_SOURCE=600
 #CFLAGS   = -g -Wall -O2 -pedantic -std=c99 -D_XOPEN_SOURCE=600 -D__FUNCTION__=__func__
-CFLAGS   = -g -Wall -O2
+CFLAGS   += -g -Wall -O2
 EXTRA_CFLAGS_PIC = -fpic
-LDFLAGS  =
+#LDFLAGS  =
 LIBS     = $(htslib_default_libs)
 
 prefix      = /usr/local


### PR DESCRIPTION
This patch contains a fix for environments where CFLAGS and LDFLAGS are already set globally, e.g., to contain additional library paths. In particular, these parameters are usually set in the R-wide Makeconf (eg. `/lib/R/etc/Makeconf`), but they were ignored here.