### PR TITLE
Respect R's CFLAGS and LDFLAGS

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rhtslib
 Type: Package
 Title: HTSlib high-throughput sequencing library as an R package
-Version: 1.17.4
+Version: 1.17.5
 Authors@R:
     c(person("Nathaniel", "Hayden", email="nhayden@fredhutch.org",
         role=c("led", "aut")),

--- a/src/htslib-1.7/Makefile.Rhtslib
+++ b/src/htslib-1.7/Makefile.Rhtslib
@@ -31,31 +31,11 @@ CC=`"${R_HOME}/bin/R" CMD config CC`
 AR=`"${R_HOME}/bin/R" CMD config AR`
 RANLIB=`"${R_HOME}/bin/R" CMD config RANLIB`
 
+# Need to deal with CPICFLAGS for this library. Irritating.
 CFLAGS=`"${R_HOME}/bin/R" CMD config CFLAGS` `"${R_HOME}/bin/R" CMD config CPICFLAGS` 
-
-
-# CC, AR, and RANLIB will be set to the values defined in
-# ${R_HOME}/etc/Makeconf when we call make with:
-#     make -f "${R_HOME}/etc/Makeconf" -f Makefile.Rhtslib
-#CC     = gcc
-#AR     = ar
-#RANLIB = ranlib
 
 # Default libraries to link if configure is not used
 htslib_default_libs = -lz -lm -lbz2 -llzma -lcurl
-
-
-
-
-
-# CPPFLAGS =
-# TODO: probably update cram code to make it compile cleanly with -Wc++-compat
-# For testing strict C99 support add -std=c99 -D_XOPEN_SOURCE=600
-#CFLAGS   = -g -Wall -O2 -pedantic -std=c99 -D_XOPEN_SOURCE=600 -D__FUNCTION__=__func__
-# CFLAGS   = -g -Wall -O2 -fpic
-# EXTRA_CFLAGS_PIC =
-# LDFLAGS  =
-# LIBS     = $(htslib_default_libs)
 
 prefix      = /usr/local
 exec_prefix = $(prefix)

--- a/src/htslib-1.7/Makefile.Rhtslib
+++ b/src/htslib-1.7/Makefile.Rhtslib
@@ -27,6 +27,13 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
+CC=`"${R_HOME}/bin/R" CMD config CC`
+AR=`"${R_HOME}/bin/R" CMD config AR`
+RANLIB=`"${R_HOME}/bin/R" CMD config RANLIB`
+
+CFLAGS=`"${R_HOME}/bin/R" CMD config CFLAGS` `"${R_HOME}/bin/R" CMD config CPICFLAGS` 
+
+
 # CC, AR, and RANLIB will be set to the values defined in
 # ${R_HOME}/etc/Makeconf when we call make with:
 #     make -f "${R_HOME}/etc/Makeconf" -f Makefile.Rhtslib
@@ -37,14 +44,18 @@
 # Default libraries to link if configure is not used
 htslib_default_libs = -lz -lm -lbz2 -llzma -lcurl
 
-CPPFLAGS =
+
+
+
+
+# CPPFLAGS =
 # TODO: probably update cram code to make it compile cleanly with -Wc++-compat
 # For testing strict C99 support add -std=c99 -D_XOPEN_SOURCE=600
 #CFLAGS   = -g -Wall -O2 -pedantic -std=c99 -D_XOPEN_SOURCE=600 -D__FUNCTION__=__func__
-CFLAGS   = -g -Wall -O2 -fpic
-EXTRA_CFLAGS_PIC =
-LDFLAGS  =
-LIBS     = $(htslib_default_libs)
+# CFLAGS   = -g -Wall -O2 -fpic
+# EXTRA_CFLAGS_PIC =
+# LDFLAGS  =
+# LIBS     = $(htslib_default_libs)
 
 prefix      = /usr/local
 exec_prefix = $(prefix)


### PR DESCRIPTION
Originally, CFLAGS and LDFLAGS were overwritten, by having uncommented lines like
```
  CFLAGS=
```
I also needed to deal with R's CPICFLAGS which are needed. I have two high-level comments
1) It is not clear to me that we need to include `RHOME/etc/Makeconf` since we now grab stuff using `R CMD config`, but I left it it. Not sure about best practices here.
2) I did not edit the Windows Makefile. But it should have similar edits I think - except I have no windows machine.

Tested on linux (under Conda) in a custom installation where this package fails to link without the correct `LDFLAGS`.