### PR TITLE
New variables to find external packages

### DIFF
--- a/src/htslib-1.7/Makefile.Rhtslib
+++ b/src/htslib-1.7/Makefile.Rhtslib
@@ -37,13 +37,13 @@
 # Default libraries to link if configure is not used
 htslib_default_libs = -lz -lm -lbz2 -llzma -lcurl
 
-CPPFLAGS += -D_FILE_OFFSET_BITS=64
+CPPFLAGS += -D_FILE_OFFSET_BITS=64 $(BZIP2_INCLUDE) $(XZ_INCLUDE)
 # TODO: probably update cram code to make it compile cleanly with -Wc++-compat
 # For testing strict C99 support add -std=c99 -D_XOPEN_SOURCE=600
 #CFLAGS   = -g -Wall -O2 -pedantic -std=c99 -D_XOPEN_SOURCE=600 -D__FUNCTION__=__func__
 CFLAGS += -fpic
 EXTRA_CFLAGS_PIC =
-#LDFLAGS  =
+LDFLAGS  += $(BZIP2_LIB) $(XZ_LIB)
 LIBS     = $(htslib_default_libs)
 
 prefix      = /usr/local


### PR DESCRIPTION
When trying to build Rhtslib in spack, the spack built bzip2 and xz
packages could not be found when the internal htslib was built. This PR
adds a couple of environment variables that can be used to define the
locations of bzip2 and xz.

- BZIP2_INCLUDE and XZ_INCLUDE: Can be set like CPPFLAGS,
  '-I/path/to/package/include'
- BZIP2_LIB and XZ_LIB: Can be set like LDFLAGS, `-L/path/to/lib'

A PR for spack that implements this is
https://github.com/spack/spack/pull/14863

This change, or similar, might be useful for other build environments as
well.