### PR TITLE
Bump version to avoid overwriting CRAM support

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Rhtslib
 Type: Package
 Title: HTSlib high-throughput sequencing library as an R package
-Version: 1.21.1.1
+Version: 1.99.9
 Authors@R:
     c(person("Nathaniel", "Hayden", email="nhayden@fredhutch.org",
         role=c("led", "aut")),


### PR DESCRIPTION
Users of `spiky` often find that the CRAM support branch of Rhtslib and Rsamtools is overwritten by new DEVEL and RELEASE bumps. 

This addresses the problem and should not affect other users.