### PR TITLE
Properly link libhts deps

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -23,7 +23,7 @@ pkgconfig <- function(opt=c("PKG_LIBS", "PKG_CPPFLAGS"))
         } else {
             ## See how PKG_LIBS is defined in Rhtslib/src/Makevars
             ## and make sure to produce the same value here.
-            libs <- "-lcurl"
+            libs <- "-lcurl -lbz2 -llzma -lz"
         }
         config <- paste(usrlib_path, libs)
     } else {

--- a/src/Makevars
+++ b/src/Makevars
@@ -9,7 +9,7 @@ HTSLIB_MAKEFILE=Makefile.Rhtslib
 
 ## Linker options. Make sure the Rhtslib::pkgconfig() function (defined in
 ## R/zzz.R) produces the same PKG_LIBS value.
-PKG_LIBS+=-lcurl
+PKG_LIBS+=-lcurl -lbz2 -llzma -lz
 
 ## Even though we should try to avoid using GNU 'make' extensions (for por-
 ## tability), we use one here to detect the platform :-/ Is there a more


### PR DESCRIPTION
libhts.a is calling several external libraries without properly linking to them. This leads to errors when cross compiling. See for example: https://github.com/r-universe/bioconductor/actions/runs/7490289085/job/20389414448

This fixes it.